### PR TITLE
Clean hyva_svg cache tag when .svg icons are edited

### DIFF
--- a/src/magento/watcher.cljs
+++ b/src/magento/watcher.cljs
@@ -224,6 +224,8 @@
     (clean-cache-for-new-controller file)
     (clean-cache-for-service-interface file)
     (remove-generated-files-based-on! file)
+    (when (string/ends-with? file ".svg")
+      (cache/clean-cache-types ["hyva_svg"]))
     (show-all-caches-disabled-notice)))
 
 (defn- queue-file! [file]


### PR DESCRIPTION
Closes https://github.com/mage2tv/magento-cache-clean/issues/113