### PR TITLE
Improve creatuity compiled interceptors support

### DIFF
--- a/src/magento/generated_code.cljs
+++ b/src/magento/generated_code.cljs
@@ -33,6 +33,15 @@
 (defn- php-class->generated-file [generated-code-dir class-name]
   (str generated-code-dir (php/php-class->file class-name)))
 
+(defn- normalize-php-class [class-name]
+  (if (string/starts-with? class-name "\\")
+    class-name
+    (str "\\" class-name)))
+
+(defn- generated-interceptor-file [base-dir php-class]
+  (when-let [dir (generated-code-dir base-dir)]
+    (php-class->generated-file dir (str (normalize-php-class php-class) "\\Interceptor"))))
+
 (defn- generated-files-for-class [base-dir php-class]
   (when-let [dir (generated-code-dir base-dir)]
     (->> php-class
@@ -80,4 +89,22 @@
       (log/notice "Removing all generated extension attributes classes")
       (log/debug (str "In base dir " base-dir ":\n")
                  (apply str (interpose ", " (map #(without-base-path base-dir %) files))))
+      (run! rm files))))
+
+(defn- di-xml-plugin-classes [di-xml]
+  (try
+    (let [contents (fs/slurp di-xml)]
+      (->> (re-seq #"<type\b[^>]*\bname\s*=\s*['\"]([^'\"]+)['\"][^>]*>[\s\S]*?</type>" contents)
+           (filter #(string/includes? (first %) "<plugin"))
+           (map second)
+           distinct))
+    (catch :default e [])))
+
+(defn remove-generated-interceptors-based-on-di-xml! [base-dir di-xml]
+  (let [files (->> (di-xml-plugin-classes di-xml)
+                   (map #(generated-interceptor-file base-dir %))
+                   (filter fs/exists?))]
+    (when (seq files)
+      (log/notice "Removing generated interceptors from" (str base-dir ":\n")
+                  (apply str (interpose ", " (map #(without-base-path base-dir %) files))))
       (run! rm files))))

--- a/src/magento/watcher.cljs
+++ b/src/magento/watcher.cljs
@@ -190,26 +190,46 @@
   (when-let [matches (re-matches #".+/etc/([a-z_]+)/di.xml$" file)]
     (get matches 1)))
 
+(defn- staticcache-dirs [base-dir]
+  [(str base-dir "generated/staticcache/")
+   (str base-dir "generated/metadata/staticcache/")])
+
+(defn- generated-metadata-staticcache? [base-dir]
+  (fs/dir? (str base-dir "generated/metadata/staticcache/")))
+
 (defn- rm-creatuity-cache-area [area]
-  (let [cache-file-name (str "generated/staticcache/global_primary_" area "_compiled_plugins.php")]
+  (let [cache-file-name (str "global_primary_" area "_compiled_plugins.php")]
     (run! (fn [base-dir]
-            (let [cache-file (str base-dir cache-file-name)]
-              (when (fs/exists? cache-file)
-                (do
-                  (log/notice "Removing creatuity interceptor cache file" cache-file)
-                  (fs/rm cache-file))))) (mage/all-base-dirs))))
+            (run! (fn [cache-dir]
+                    (let [cache-file (str cache-dir cache-file-name)]
+                      (when (fs/exists? cache-file)
+                        (do
+                          (log/notice "Removing creatuity interceptor cache file" cache-file)
+                          (fs/rm cache-file)))))
+                  (staticcache-dirs base-dir)))
+          (mage/all-base-dirs))))
 
 (defn- rm-creatuity-cache []
-  (run! #(let [cache-dir (str % "generated/staticcache/")]
-           (when (fs/dir? cache-dir)
-             (do
-               (log/notice "Removing creatuity interceptors cache" cache-dir)
-               (fs/rm-contents cache-dir)))) (mage/all-base-dirs)))
+  (run! (fn [base-dir]
+          (run! (fn [cache-dir]
+                  (when (fs/dir? cache-dir)
+                    (do
+                      (log/notice "Removing creatuity interceptors cache" cache-dir)
+                      (fs/rm-contents cache-dir))))
+                (staticcache-dirs base-dir)))
+        (mage/all-base-dirs)))
+
+(defn- remove-generated-interceptors-for-di-xml! [file]
+  (run! (fn [base-dir]
+          (when (generated-metadata-staticcache? base-dir)
+            (generated/remove-generated-interceptors-based-on-di-xml! base-dir file)))
+        (mage/all-base-dirs)))
 
 (defn- clean-creatuity-interceptor-cache [file]
   (if-let [area (di-xml-area file)]
     (rm-creatuity-cache-area area)
-    (rm-creatuity-cache)))
+    (rm-creatuity-cache))
+  (remove-generated-interceptors-for-di-xml! file))
 
 (defn file-changed [file]
   (when (process-changed-file? file)


### PR DESCRIPTION
This change introduces the following:

It seems that creatuity now uses the /metadata/ folder for storing their files. This PR makes it so that in both folders we are able to see / clear those files. (https://github.com/creatuity/magento2-interceptors/commit/322d32ef0afa5b6ed046df3436ac63b0e36b6969)

The default workflow when XML changes flushes the resolvers/config cache. This works in Magento; since it looks into the config for every request, but the creatuity module does not use this config, making it so changes to XML are not applied. We now delete the generated interceptor so creatuity can generate a new one.
 	